### PR TITLE
gh-pages fix: bypass jekyll, allow files with underscore

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,6 +18,7 @@ jobs:
         node-version: '10'
     - run: yarn install --frozen-lockfile
     - run: yarn doc
+    - run: touch docs/.nojekyll
     - name: Deploy docs 🚀
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,6 +18,12 @@ jobs:
         node-version: '10'
     - run: yarn install --frozen-lockfile
     - run: yarn doc
+
+    # start: temporary fix for broken link on nash.io/developers
+    - run: mkdir docs/docs
+    - run: echo "<a href='https://nash-io.github.io/api-client-typescript/'>Please visit https://nash-io.github.io/api-client-typescript/</a>" > docs/docs/index.html
+    # end: temporary fix
+
     - run: touch docs/.nojekyll
     - name: Deploy docs 🚀
       uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/