### PR TITLE
Ts/update nash protocol fillorder

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2-beta
       with:
-        node-version: '10'
+        node-version: '14'
     - run: yarn install --frozen-lockfile
     - run: yarn test:lint
     - run: yarn test:unit

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2-beta
       with:
-        node-version: '10'
+        node-version: '14'
     - run: yarn install --frozen-lockfile
     - run: yarn doc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="6.0.1"></a>
+## [6.0.1](https://github.com/nash-io/api-client-typescript/compare/v5.2.25...v6.0.1) (2020-12-15)
+
 <a name="5.2.29"></a>
 ## [5.2.29](https://github.com/nash-io/api-client-typescript/compare/v5.2.27...v5.2.29) (2021-01-19)
 
@@ -9,7 +12,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 <a name="5.2.27"></a>
 ## [5.2.27](https://github.com/nash-io/api-client-typescript/compare/v5.2.25...v5.2.27) (2020-12-16)
-
 
 
 <a name="5.2.25"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="6.0.3"></a>
+## [6.0.3](https://github.com/nash-io/api-client-typescript/compare/v5.2.29...v6.0.3) (2021-01-21)
+
+
+
 <a name="6.0.1"></a>
 ## [6.0.1](https://github.com/nash-io/api-client-typescript/compare/v5.2.25...v6.0.1) (2020-12-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="6.0.5"></a>
+## [6.0.5](https://github.com/nash-io/api-client-typescript/compare/v6.0.3...v6.0.5) (2021-01-21)
+
+
+
 <a name="6.0.3"></a>
 ## [6.0.3](https://github.com/nash-io/api-client-typescript/compare/v5.2.29...v6.0.3) (2021-01-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="6.0.7"></a>
+## [6.0.7](https://github.com/nash-io/api-client-typescript/compare/v5.2.25...v6.0.7) (2021-01-26)
+
+
+
 <a name="6.0.5"></a>
 ## [6.0.5](https://github.com/nash-io/api-client-typescript/compare/v6.0.3...v6.0.5) (2021-01-21)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ NOTE: In sandbox, testnet funds are automatically sent to new accounts. The sand
 
 ## Installation
 
+Requires usage of Node 14 or greater.
+
 ```sh
 yarn add @neon-exchange/api-client-typescript
 ```
@@ -19,6 +21,11 @@ yarn add @neon-exchange/api-client-typescript
 
 To get started you need to create an API key. You can find instructions on how to do so further down in this Readme.
 Remember, API Keys contain sensitive infomation, if you are using version control be careful not to store the key in the repository.
+
+## API Compatibility
+
+Versions 6 and above include a change to order placement logic. The previous order placement logic will no longer be compatible with the exchange, so it is highly recommended to upgrade to version 6 or higher as previous versions will be deprecated.
+
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neon-exchange/api-client-typescript",
-  "version": "6.0.3",
+  "version": "6.0.5",
   "description": "Official TypeScript client for interacting with the Nash exchange",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,13 +56,13 @@
     "prepare-release": "One-step: clean, build, test, publish docs, and prep a release"
   },
   "engines": {
-    "node": ">=8.9 <11.0.0"
+    "node": ">=8.9 <16.0.0"
   },
   "dependencies": {
     "@absinthe/socket": "0.2.1",
     "@cityofzion/neon-js": "4.7.2",
     "@neon-exchange/nash-perf": "1.0.4",
-    "@neon-exchange/nash-protocol": "3.3.12",
+    "@neon-exchange/nash-protocol": "4.0.1",
     "@types/isomorphic-fetch": "0.0.35",
     "@types/node": "13.9.8",
     "@types/request": "2.48.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neon-exchange/api-client-typescript",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "description": "Official TypeScript client for interacting with the Nash exchange",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -62,7 +62,7 @@
     "@absinthe/socket": "0.2.1",
     "@cityofzion/neon-js": "4.7.2",
     "@neon-exchange/nash-perf": "1.0.4",
-    "@neon-exchange/nash-protocol": "4.0.1",
+    "@neon-exchange/nash-protocol": "^4.0.3",
     "@types/isomorphic-fetch": "0.0.35",
     "@types/node": "13.9.8",
     "@types/request": "2.48.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neon-exchange/api-client-typescript",
-  "version": "5.2.29",
+  "version": "6.0.1",
   "description": "Official TypeScript client for interacting with the Nash exchange",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,13 +56,13 @@
     "prepare-release": "One-step: clean, build, test, publish docs, and prep a release"
   },
   "engines": {
-    "node": ">=8.9 <16.0.0"
+    "node": ">=14.3"
   },
   "dependencies": {
     "@absinthe/socket": "0.2.1",
     "@cityofzion/neon-js": "4.7.2",
     "@neon-exchange/nash-perf": "1.0.4",
-    "@neon-exchange/nash-protocol": "4.0.5",
+    "@neon-exchange/nash-protocol": "4.0.7",
     "@types/isomorphic-fetch": "0.0.35",
     "@types/node": "13.9.8",
     "@types/request": "2.48.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neon-exchange/api-client-typescript",
-  "version": "6.0.5",
+  "version": "6.0.7",
   "description": "Official TypeScript client for interacting with the Nash exchange",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@absinthe/socket": "0.2.1",
     "@cityofzion/neon-js": "4.7.2",
     "@neon-exchange/nash-perf": "1.0.4",
-    "@neon-exchange/nash-protocol": "^4.0.3",
+    "@neon-exchange/nash-protocol": "4.0.5",
     "@types/isomorphic-fetch": "0.0.35",
     "@types/node": "13.9.8",
     "@types/request": "2.48.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     node-fetch "2.6.0"
     semver "7.3.2"
 
-"@neon-exchange/nash-protocol@3.3.12":
-  version "3.3.12"
-  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-3.3.12.tgz#c4307ad227237f2ba54b3008e7b873bc12431b7f"
-  integrity sha512-jjFmeGh2lEaFpXJnjZbsEcJPWOsaSAc1HFrtn7gyI8844mEjt9P2mcPJrWuzBbQ3TMFs4ESSXs4qZkZeun/HfA==
+"@neon-exchange/nash-protocol@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.1.tgz#08cb668d2b2e340b5acfc5a19eed0c67b81d7b70"
+  integrity sha512-9mUGxMytKUAe1UTU5MafUDru9jf6BiNScfhP5yrcwnQ9+DCgRhf6QyOdQGAtbKtZsv+tPsKaA5S6xYiTQxxj5A==
   dependencies:
     bignumber.js "8.1.1"
     bip32 "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     node-fetch "2.6.0"
     semver "7.3.2"
 
-"@neon-exchange/nash-protocol@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.3.tgz#7a09101bb0b36e799d2a67cf08b521db17d6f9cb"
-  integrity sha512-60PekVb3/iQ96+Fg+0EX+NPiIDAq9WfN70h6UEp5kEYQb25VSRU0eIkwwu5W5QDe7QYJOHp7Wb29wuwLuXCP1w==
+"@neon-exchange/nash-protocol@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.5.tgz#df0bb50c757b51c612035542f982d8efcaffe0a5"
+  integrity sha512-JtG5ctNxgEf/wrWfD7Z2NPZqIIlGjQX+U2HmCRrwWPtJWeh6nDMbTJ42bN8kbthFt1RyxJZRPQgInqIhRZbnyA==
   dependencies:
     bignumber.js "8.1.1"
     bip32 "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     node-fetch "2.6.0"
     semver "7.3.2"
 
-"@neon-exchange/nash-protocol@4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.5.tgz#df0bb50c757b51c612035542f982d8efcaffe0a5"
-  integrity sha512-JtG5ctNxgEf/wrWfD7Z2NPZqIIlGjQX+U2HmCRrwWPtJWeh6nDMbTJ42bN8kbthFt1RyxJZRPQgInqIhRZbnyA==
+"@neon-exchange/nash-protocol@4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.7.tgz#65c927db5a0c38e1e58c7bc7ba1853d45900c132"
+  integrity sha512-9AVwl61ZpLA3KiM9fRVpG/y0OoYepwwrEk4ZlSBd2FeVCmGqN8cR0VN9DkkVLipD+mQ6/TC88Ym4odp7T7KJmw==
   dependencies:
     bignumber.js "8.1.1"
     bip32 "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
     node-fetch "2.6.0"
     semver "7.3.2"
 
-"@neon-exchange/nash-protocol@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.1.tgz#08cb668d2b2e340b5acfc5a19eed0c67b81d7b70"
-  integrity sha512-9mUGxMytKUAe1UTU5MafUDru9jf6BiNScfhP5yrcwnQ9+DCgRhf6QyOdQGAtbKtZsv+tPsKaA5S6xYiTQxxj5A==
+"@neon-exchange/nash-protocol@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@neon-exchange/nash-protocol/-/nash-protocol-4.0.3.tgz#7a09101bb0b36e799d2a67cf08b521db17d6f9cb"
+  integrity sha512-60PekVb3/iQ96+Fg+0EX+NPiIDAq9WfN70h6UEp5kEYQb25VSRU0eIkwwu5W5QDe7QYJOHp7Wb29wuwLuXCP1w==
   dependencies:
     bignumber.js "8.1.1"
     bip32 "2.0.3"
@@ -1598,7 +1598,20 @@ bip32@2.0.3:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
-bip32@^2.0.3, bip32@^2.0.4:
+bip32@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.6.tgz#6a81d9f98c4cd57d05150c60d8f9e75121635134"
+  integrity sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==
+  dependencies:
+    "@types/node" "10.12.18"
+    bs58check "^2.1.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    tiny-secp256k1 "^1.1.3"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
+bip32@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.5.tgz#e3808a9e97a880dbafd0f5f09ca4a1e14ee275d2"
   integrity sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==
@@ -6253,9 +6266,9 @@ nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nan@^2.2.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nano-json-stream-parser@^0.1.2:
   version "0.1.2"
@@ -8488,9 +8501,9 @@ tiny-secp256k1@1.1.3, tiny-secp256k1@^1.1.1, tiny-secp256k1@^1.1.3:
     nan "^2.13.2"
 
 tiny-secp256k1@^1.1.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz#3dc37b9bf0fa5b4390b9fa29e953228810cebc18"
-  integrity sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz#7e224d2bee8ab8283f284e40e6b4acb74ffe047c"
+  integrity sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==
   dependencies:
     bindings "^1.3.0"
     bn.js "^4.11.8"


### PR DESCRIPTION
Updates to use latest major version of @neonexchange/nash-protocol.  This change is only compatible with NodeJS versions 14 and greater.

Versions 6 and above include a change to order placement logic. The previous order placement logic will no longer be compatible with the exchange, so it is highly recommended to upgrade to version 6 or higher as previous versions will be deprecated.
